### PR TITLE
Update Preact link due to git.io deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Examples are included for both "Classful" Components, and stateless pure functio
 
 > :horse: Supporting older browsers?  Check out [Preact in ES3](https://github.com/developit/preact-in-es3)
 
-[Preact]: https://git.io/preact
+[Preact]: https://github.com/preactjs/preact


### PR DESCRIPTION
Update https://git.io/preact to point to https://github.com/preactjs/preact,
since git.io is disappearing in a few days:
https://github.blog/changelog/2022-04-25-git-io-deprecation/